### PR TITLE
Add volatility filter

### DIFF
--- a/strategies/base.py
+++ b/strategies/base.py
@@ -14,6 +14,10 @@ class BaseStrategy:
     # Allowed market regimes for this strategy. Scheduler will block trades if
     # the detected regime is not listed here.  Defaults to trending only.
     ALLOWED_REGIMES: set[str] = {"trending", "volatile"}
+
+    def is_volatile_enough(self, atr_series: pd.Series, threshold: float = 1.0) -> bool:
+        """Return True if the latest ATR value exceeds the threshold."""
+        return atr_series.iloc[-1] > threshold
     
     def allowed_regimes(self) -> list[str]:
         """Return allowed market regimes for this strategy."""

--- a/strategies/breakout_strategy.py
+++ b/strategies/breakout_strategy.py
@@ -44,6 +44,9 @@ class BreakoutStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -54,6 +57,9 @@ class BreakoutStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="Breakout")
         return self.signal

--- a/strategies/delta_scalping.py
+++ b/strategies/delta_scalping.py
@@ -29,6 +29,9 @@ class DeltaDivergenceScalpingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -39,6 +42,9 @@ class DeltaDivergenceScalpingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="DeltaScalping")
         return self.signal

--- a/strategies/ema_crossover_scalping.py
+++ b/strategies/ema_crossover_scalping.py
@@ -32,6 +32,9 @@ class EMACrossoverScalpingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -43,5 +46,8 @@ class EMACrossoverScalpingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="EMACrossover")

--- a/strategies/fibonacci_swing.py
+++ b/strategies/fibonacci_swing.py
@@ -36,6 +36,9 @@ class FibonacciSwingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -46,6 +49,9 @@ class FibonacciSwingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="FibonacciSwing")
         return self.signal

--- a/strategies/ichimoku_day.py
+++ b/strategies/ichimoku_day.py
@@ -62,6 +62,9 @@ class IchimokuDayStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -72,6 +75,9 @@ class IchimokuDayStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="IchimokuDay")
         return self.signal

--- a/strategies/ict_smart_money.py
+++ b/strategies/ict_smart_money.py
@@ -11,6 +11,8 @@ class ICTSmartMoneyStrategy(BaseStrategy):
     """Strategy leveraging ICT style concepts."""
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         if len(df) < 5:
             self._log_context(df, pattern_detected="ICTSmartMoney")
             return None
@@ -29,6 +31,8 @@ class ICTSmartMoneyStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)

--- a/strategies/london_breakout.py
+++ b/strategies/london_breakout.py
@@ -31,6 +31,9 @@ class LondonBreakoutStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -41,6 +44,9 @@ class LondonBreakoutStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="LondonBreakout")
         return self.signal

--- a/strategies/ma_crossover_swing.py
+++ b/strategies/ma_crossover_swing.py
@@ -36,6 +36,9 @@ class MACrossoverSwingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -47,6 +50,9 @@ class MACrossoverSwingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="MACrossover")
         return self.signal

--- a/strategies/macd_divergence.py
+++ b/strategies/macd_divergence.py
@@ -33,6 +33,9 @@ class MACDDivergenceStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -43,6 +46,9 @@ class MACDDivergenceStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="MACDDivergence")
         return self.signal

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -38,6 +38,9 @@ class MeanReversionStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -48,6 +51,9 @@ class MeanReversionStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="MeanReversion")
         return self.signal

--- a/strategies/micro_breakout_scalping.py
+++ b/strategies/micro_breakout_scalping.py
@@ -33,6 +33,9 @@ class MicroBreakoutScalpingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -43,6 +46,9 @@ class MicroBreakoutScalpingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="MicroBreakout")
         return self.signal

--- a/strategies/order_block_scalping.py
+++ b/strategies/order_block_scalping.py
@@ -34,6 +34,9 @@ class OrderBlockScalpingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -44,6 +47,9 @@ class OrderBlockScalpingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="OrderBlockScalping", entry_zone="OB")
         return self.signal

--- a/strategies/price_action_strategy.py
+++ b/strategies/price_action_strategy.py
@@ -13,6 +13,8 @@ class PriceActionStrategy(BaseStrategy):
     """Basic strategy using price action utilities."""
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         if len(df) < 5:
             self._log_context(df, pattern_detected="PriceAction")
             return None
@@ -34,6 +36,8 @@ class PriceActionStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)

--- a/strategies/smc_strategy.py
+++ b/strategies/smc_strategy.py
@@ -27,6 +27,8 @@ class SMCStrategy(BaseStrategy):
     strategy_group = "day"
 
     def generate_signal(self, df: pd.DataFrame) -> Dict | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         if df is None or df.empty:
             return None
         if not in_killzone(df.index[-1].to_pydatetime()):
@@ -76,6 +78,8 @@ class SMCStrategy(BaseStrategy):
         }
 
     def check_signal(self, symbol: str, timeframe: str, df: pd.DataFrame, regime: str) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            return None
         trade = self.generate_signal(df)
         if trade:
             return trade.get("direction")

--- a/strategies/supertrend_adx_rsi_strategy.py
+++ b/strategies/supertrend_adx_rsi_strategy.py
@@ -46,6 +46,9 @@ class SupertrendADXRSIStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -56,6 +59,9 @@ class SupertrendADXRSIStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="SupertrendADXRSI")
         return self.signal

--- a/strategies/supply_demand_swing.py
+++ b/strategies/supply_demand_swing.py
@@ -32,6 +32,9 @@ class SupplyDemandSwingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -42,6 +45,9 @@ class SupplyDemandSwingStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="SupplyDemand")
         return self.signal

--- a/strategies/trend_breakout.py
+++ b/strategies/trend_breakout.py
@@ -98,6 +98,9 @@ class TrendBreakoutStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -122,6 +125,9 @@ class TrendBreakoutStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="TrendBreakout")
         return self.signal

--- a/strategies/trend_following.py
+++ b/strategies/trend_following.py
@@ -41,6 +41,9 @@ class TrendFollowingStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.last_signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -51,6 +54,9 @@ class TrendFollowingStrategy(BaseStrategy):
         return self.last_signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.last_signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="TrendFollowing")
         return self.last_signal

--- a/strategies/trend_pullback.py
+++ b/strategies/trend_pullback.py
@@ -32,6 +32,9 @@ class TrendPullbackStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -43,6 +46,9 @@ class TrendPullbackStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="TrendPullback")
         return self.signal

--- a/strategies/volume_breakout.py
+++ b/strategies/volume_breakout.py
@@ -30,6 +30,9 @@ class VolumeBreakoutStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -40,6 +43,9 @@ class VolumeBreakoutStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="VolumeBreakout")
         return self.signal

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -44,6 +44,9 @@ class VWAPReversionStrategy(BaseStrategy):
         df: pd.DataFrame,
         regime: str,
     ) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         import logging
 
         self.logger = logging.getLogger(__name__)
@@ -54,6 +57,9 @@ class VWAPReversionStrategy(BaseStrategy):
         return self.signal
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
+        if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
+            self.signal = None
+            return None
         self.analyze(df)
         self._log_context(df, pattern_detected="VWAPReversion", entry_zone="VWAP")
         return self.signal


### PR DESCRIPTION
## Summary
- implement `is_volatile_enough` in BaseStrategy
- skip signal generation when ATR is below threshold across all strategies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862faa71150832a85087352ced237b1