### PR TITLE
Implement symbol-specific strategy scoring

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@ Welcome to the AutoTrade AI Bot — an intelligent, modular, and fully automated
 ## 🚀 Project Features
 
 * ✅ AI-powered strategy selection
+* ✅ Symbol-specific scoring via `strategy_scores_by_asset.json`
 * ✅ Modular agent-based architecture
 * ✅ Multi-symbol, multi-timeframe support
 * ✅ Dynamic SL/TP & breakeven logic

--- a/agents/strategy_evaluator_agent.py
+++ b/agents/strategy_evaluator_agent.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from strategies.base import BaseStrategy
 from ai_engine.strategy_selector import load_scores
+from ai_engine.score_updater import load_asset_scores
 from config.settings import DEFAULT_CONFIDENCE_THRESHOLDS
 import logging
 
@@ -14,8 +15,13 @@ logger = logging.getLogger(__name__)
 class StrategyEvaluatorAgent:
     """Score strategies using stored metrics."""
 
-    def __init__(self, score_path: str = "ai_engine/strategy_scores.json") -> None:
+    def __init__(
+        self,
+        score_path: str = "ai_engine/strategy_scores.json",
+        asset_score_path: str = "ai_engine/strategy_scores_by_asset.json",
+    ) -> None:
         self.score_path = score_path
+        self.asset_score_path = asset_score_path
 
     def evaluate(
         self,
@@ -30,6 +36,7 @@ class StrategyEvaluatorAgent:
             scores = load_scores(self.score_path)
         except TypeError:
             scores = load_scores()
+        asset_scores = load_asset_scores(self.asset_score_path)
         results: List[Dict] = []
         base_score = DEFAULT_CONFIDENCE_THRESHOLDS.get(regime, 0.3)
         for strat in strategies:
@@ -41,15 +48,19 @@ class StrategyEvaluatorAgent:
             if signal == "sell" and regime in {"uptrend"}:
                 logger.info(f"Skipping {name}: sell signal blocked in {regime} regime.")
                 continue
-            metrics = scores.get(name)
-            if not metrics:
-                confidence = base_score
+            sym_score = asset_scores.get(symbol or "", {}).get(name)
+            if sym_score is not None:
+                confidence = float(sym_score)
             else:
-                fit = float(metrics.get("regime_fit", 1.0))
-                win = float(metrics.get("win_rate", 0.0))
-                recent = float(metrics.get("recent_score", 0.0))
-                confidence = (win / 100.0) * recent * fit
-                if confidence == 0:
+                metrics = scores.get(name)
+                if not metrics:
                     confidence = base_score
+                else:
+                    fit = float(metrics.get("regime_fit", 1.0))
+                    win = float(metrics.get("win_rate", 0.0))
+                    recent = float(metrics.get("recent_score", 0.0))
+                    confidence = (win / 100.0) * recent * fit
+                    if confidence == 0:
+                        confidence = base_score
             results.append({"strategy": strat, "signal": signal, "score": confidence})
         return results

--- a/agents/strategy_selector_agent.py
+++ b/agents/strategy_selector_agent.py
@@ -25,15 +25,23 @@ EPSILON = 0.05
 class StrategySelectorAgent:
     """High level decision maker for choosing a trading direction."""
 
-    def __init__(self, strategies: Iterable[BaseStrategy], score_path: str = "ai_engine/strategy_scores.json") -> None:
+    def __init__(
+        self,
+        strategies: Iterable[BaseStrategy],
+        score_path: str = "ai_engine/strategy_scores.json",
+        asset_score_path: str = "ai_engine/strategy_scores_by_asset.json",
+    ) -> None:
         self.strategies = list(strategies)
         self._strategy_cycle = cycle(self.strategies)
         self.scanner = MarketScannerAgent()
-        self.evaluator = StrategyEvaluatorAgent(score_path=score_path)
+        self.evaluator = StrategyEvaluatorAgent(
+            score_path=score_path, asset_score_path=asset_score_path
+        )
         self.memory = MemoryEvaluatorAgent(score_path=score_path)
         # Block strategies after two consecutive losses
         self.guard = StreakGuard(streak=2)
         self.score_path = score_path
+        self.asset_score_path = asset_score_path
 
     def select(self, symbol: str, timeframe: str) -> Tuple[str | None, str | None, str]:
         df, regime = self.scanner.scan(symbol, timeframe)

--- a/agents/trade_monitor_agent.py
+++ b/agents/trade_monitor_agent.py
@@ -110,11 +110,23 @@ class TradeMonitorAgent:
 
             sig = inspect.signature(update_strategy_score)
             if len(sig.parameters) >= 4:
-                update_strategy_score(self.strategy, result_str, net_pct, regime=self.regime)
+                update_strategy_score(
+                    self.strategy,
+                    result_str,
+                    net_pct,
+                    regime=self.regime,
+                    symbol=self.symbol,
+                )
             else:
                 update_strategy_score(self.strategy, result_str, self.regime)
         except Exception:
-            update_strategy_score(self.strategy, result_str, net_pct, regime=self.regime)
+            update_strategy_score(
+                self.strategy,
+                result_str,
+                net_pct,
+                regime=self.regime,
+                symbol=self.symbol,
+            )
         logger.debug(
             "Trade closed: %s %s result=%s net_pct=%.2f",
             self.symbol,

--- a/ai_engine/score_updater.py
+++ b/ai_engine/score_updater.py
@@ -12,6 +12,7 @@ import os
 from typing import Dict, Iterable
 
 DEFAULT_SCORE_PATH = "ai_engine/strategy_scores.json"
+DEFAULT_ASSET_SCORE_PATH = "ai_engine/strategy_scores_by_asset.json"
 MIN_BASE_SCORE = 0.05
 
 def _load_json(path: str) -> Dict[str, dict]:
@@ -30,6 +31,28 @@ def _save_json(data: Dict[str, dict], path: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:
         json.dump(data, f, indent=2)
+
+
+def load_asset_scores(path: str = DEFAULT_ASSET_SCORE_PATH) -> Dict[str, dict]:
+    """Return per-symbol strategy scores from ``path``."""
+    return _load_json(path)
+
+
+def _update_asset_score(
+    symbol: str,
+    strategy_name: str,
+    score: float,
+    *,
+    path: str = DEFAULT_ASSET_SCORE_PATH,
+    alpha: float = 0.1,
+) -> None:
+    """Update ``strategy_scores_by_asset.json`` for ``symbol`` and strategy."""
+    data = load_asset_scores(path)
+    sym_map = data.setdefault(symbol, {})
+    prev = float(sym_map.get(strategy_name, score))
+    sym_map[strategy_name] = (1 - alpha) * prev + alpha * score
+    data[symbol] = sym_map
+    _save_json(data, path)
 
 def initialize_scores(
     strategy_names: Iterable[str],
@@ -97,9 +120,12 @@ def update_scores(results: Dict[str, dict], score_path: str = DEFAULT_SCORE_PATH
 def update_strategy_score(
     strategy_name: str,
     result: str,
-    net_profit_pct: float,
+    net_profit_pct: float | None,
     regime: str,
+    *,
+    symbol: str | None = None,
     score_path: str = DEFAULT_SCORE_PATH,
+    asset_score_path: str = DEFAULT_ASSET_SCORE_PATH,
     alpha: float = 0.1,
 ) -> None:
     """Update metrics for ``strategy_name`` after a closed trade.
@@ -141,6 +167,14 @@ def update_strategy_score(
         strat_map[regime] = metrics
         scores[strategy_name] = strat_map
         _save_json(scores, score_path)
+        if symbol:
+            _update_asset_score(
+                symbol,
+                strategy_name,
+                calculate_composite_score(metrics),
+                path=asset_score_path,
+                alpha=alpha,
+            )
         return
 
     outcome = str(result or "").lower()
@@ -168,6 +202,14 @@ def update_strategy_score(
     strat_map[regime] = metrics
     scores[strategy_name] = strat_map
     _save_json(scores, score_path)
+    if symbol:
+        _update_asset_score(
+            symbol,
+            strategy_name,
+            calculate_composite_score(metrics),
+            path=asset_score_path,
+            alpha=alpha,
+        )
 
 def load_scores(path: str = DEFAULT_SCORE_PATH) -> Dict[str, dict]:
     """Load score metrics from ``path``."""

--- a/ai_engine/strategy_scores_by_asset.json
+++ b/ai_engine/strategy_scores_by_asset.json
@@ -1,0 +1,8 @@
+{
+  "BTCUSD": {
+    "SMCStrategy": 0.78
+  },
+  "XAUUSD": {
+    "EMA2CrossStrategy": 0.61
+  }
+}

--- a/ai_engine/trade_replayer.py
+++ b/ai_engine/trade_replayer.py
@@ -73,7 +73,14 @@ class ReplayEngine:
             outcome = "win" if result.startswith("tp") or result == "win" else "loss"
             net_pct = float(t.get("net_profit_pct", 0.0))
             if not dry_run:
-                update_strategy_score(strat, outcome, net_pct, regime=regime, score_path=self.score_path)
+                update_strategy_score(
+                    strat,
+                    outcome,
+                    net_pct,
+                    regime=regime,
+                    symbol=str(t.get("symbol", "")),
+                    score_path=self.score_path,
+                )
             c = counts.setdefault(strat, {"wins": 0, "losses": 0, "processed": 0})
             c["processed"] += 1
             if outcome == "win":

--- a/backtesting/live_simulator.py
+++ b/backtesting/live_simulator.py
@@ -125,7 +125,13 @@ def run_simulation():
                     regime,
                 )
                 pct = (pnl / (entry * volume * 100000.0) * 100) if entry and volume else 0.0
-                update_strategy_score(strategy_name, result, pct, regime)
+                update_strategy_score(
+                    strategy_name,
+                    result,
+                    pct,
+                    regime,
+                    symbol=symbol,
+                )
                 print(f"📊 {strategy_name} → {result.upper()} | PnL: ${round(pnl, 2)} | New Balance: ${round(balance, 2)}")
 
         time.sleep(CHECK_INTERVAL_SECONDS)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -56,8 +56,14 @@ def test_strategy_selector_agent(tmp_path, monkeypatch):
 
     from ai_engine import strategy_selector as ss
     monkeypatch.setattr(ss, "load_scores", lambda path=str(score_path): json.load(open(path)))
+    from ai_engine import score_updater as su
+    monkeypatch.setattr(su, "load_asset_scores", lambda path="": {})
 
-    agent = StrategySelectorAgent([GoodStrategy(), BadStrategy()], score_path=str(score_path))
+    agent = StrategySelectorAgent(
+        [GoodStrategy(), BadStrategy()],
+        score_path=str(score_path),
+        asset_score_path=str(score_path),
+    )
     decision, strat_name, regime = agent.select("XAUUSD", "M1")
     assert decision == "buy"
     assert strat_name == "GoodStrategy"

--- a/tests/test_asset_scores.py
+++ b/tests/test_asset_scores.py
@@ -7,17 +7,67 @@ class Dummy(BaseStrategy):
         return "buy"
 
 
-def test_symbol_specific_score_override(tmp_path):
+def test_symbol_specific_score_override(tmp_path, monkeypatch):
     score_path = tmp_path / "scores.json"
+    with open(score_path, "w") as f:
+        json.dump(
+            {
+                "Dummy": {
+                    "trending": {
+                        "win_rate": 50.0,
+                        "recent_score": 1.0,
+                        "regime_fit": 1.0,
+                    }
+                }
+            },
+            f,
+        )
+    asset_path = tmp_path / "asset.json"
+    with open(asset_path, "w") as f:
+        json.dump({"XAUUSD": {"Dummy": 0.42}}, f)
+
+    from ai_engine import strategy_selector as ss
+    import importlib.util, importlib.machinery, os
+    path = os.path.join("ai_engine", "strategy_selector.py")
+    spec = importlib.util.spec_from_file_location("real_selector", path)
+    real_selector = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(real_selector)
+
+    monkeypatch.setattr(ss, "load_scores", lambda path=str(score_path): real_selector.load_scores(path))
+    import agents.strategy_evaluator_agent as eva
+    monkeypatch.setattr(eva, "load_scores", lambda path=str(score_path): real_selector.load_scores(path))
+
+    agent = StrategyEvaluatorAgent(score_path=str(score_path), asset_score_path=str(asset_path))
+    class DF: pass
+    res = agent.evaluate([Dummy()], DF(), "trending", symbol="XAUUSD", timeframe="M1")
+    assert res and abs(res[0]["score"] - 0.42) < 1e-6
+
+
+def test_fallback_to_global_score(tmp_path, monkeypatch):
+    score_path = tmp_path / "scores.json"
+    # global metrics yield composite score of 0.5
     with open(score_path, "w") as f:
         json.dump({
             "Dummy": {"trending": {"win_rate": 50.0, "recent_score": 1.0, "regime_fit": 1.0}}
         }, f)
     asset_path = tmp_path / "asset.json"
     with open(asset_path, "w") as f:
-        json.dump({"XAUUSD": {"Dummy": 0.42}}, f)
+        json.dump({}, f)
+
+    from ai_engine import strategy_selector as ss
+    import importlib.util, importlib.machinery, os
+    path = os.path.join("ai_engine", "strategy_selector.py")
+    spec = importlib.util.spec_from_file_location("real_selector", path)
+    real_selector = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(real_selector)
+
+    monkeypatch.setattr(ss, "load_scores", lambda path=str(score_path): real_selector.load_scores(path))
+    import agents.strategy_evaluator_agent as eva
+    monkeypatch.setattr(eva, "load_scores", lambda path=str(score_path): real_selector.load_scores(path))
 
     agent = StrategyEvaluatorAgent(score_path=str(score_path), asset_score_path=str(asset_path))
     class DF: pass
-    res = agent.evaluate([Dummy()], DF(), "trending", symbol="XAUUSD", timeframe="M1")
-    assert res and abs(res[0]["score"] - 0.42) < 1e-6
+    res = agent.evaluate([Dummy()], DF(), "trending", symbol="BTCUSD", timeframe="M1")
+    assert res and abs(res[0]["score"] - 0.5) < 1e-6

--- a/tests/test_asset_scores.py
+++ b/tests/test_asset_scores.py
@@ -1,0 +1,23 @@
+import json
+from agents.strategy_evaluator_agent import StrategyEvaluatorAgent
+from strategies.base import BaseStrategy
+
+class Dummy(BaseStrategy):
+    def generate_signal(self, df):
+        return "buy"
+
+
+def test_symbol_specific_score_override(tmp_path):
+    score_path = tmp_path / "scores.json"
+    with open(score_path, "w") as f:
+        json.dump({
+            "Dummy": {"trending": {"win_rate": 50.0, "recent_score": 1.0, "regime_fit": 1.0}}
+        }, f)
+    asset_path = tmp_path / "asset.json"
+    with open(asset_path, "w") as f:
+        json.dump({"XAUUSD": {"Dummy": 0.42}}, f)
+
+    agent = StrategyEvaluatorAgent(score_path=str(score_path), asset_score_path=str(asset_path))
+    class DF: pass
+    res = agent.evaluate([Dummy()], DF(), "trending", symbol="XAUUSD", timeframe="M1")
+    assert res and abs(res[0]["score"] - 0.42) < 1e-6

--- a/utils/trade_journal.py
+++ b/utils/trade_journal.py
@@ -179,6 +179,7 @@ def update_trade(
                             outcome,
                             net_val,
                             regime=trade.get("regime", ""),
+                            symbol=trade.get("symbol", ""),
                         )
             # Fetch exit details if missing and trade has closed
             if result and result.lower() != "open" and trade.get("exit") in (None, 0.0):


### PR DESCRIPTION
## Summary
- add strategy_scores_by_asset.json for per-symbol scores
- extend score_updater to load and update asset-specific scores
- support asset scores in StrategyEvaluatorAgent and StrategySelectorAgent
- pass symbol info when updating strategy score
- adjust tests and add new asset score test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863074b2674832a8b273850736903f9