### PR TITLE
Centralized indicator utilities and strategy refactor

### DIFF
--- a/dev/check_strategy_indicators.py
+++ b/dev/check_strategy_indicators.py
@@ -1,0 +1,15 @@
+import os
+
+indicator_keywords = [
+    'calculate_ema', 'calculate_sma', 'calculate_rsi', 'calculate_macd',
+    'calculate_vwap', 'calculate_supertrend', 'calculate_adx',
+    'calculate_bollinger_bands'
+]
+
+for file in os.listdir('strategies'):
+    if not file.endswith('.py'):
+        continue
+    with open(f'strategies/{file}', 'r') as f:
+        content = f.read()
+        found = any(kw in content for kw in indicator_keywords)
+        print(f"{file:<35} → {'✅' if found else '❌ NO INDICATORS'}")

--- a/strategies/delta_scalping.py
+++ b/strategies/delta_scalping.py
@@ -1,3 +1,4 @@
+# ⛔ No indicators required – this strategy uses raw price-action triggers only.
 import pandas as pd
 from .base import BaseStrategy
 

--- a/strategies/ict_10am_manipulation.py
+++ b/strategies/ict_10am_manipulation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# ⛔ No indicators required – this strategy uses raw price-action triggers only.
 from datetime import time
 import pandas as pd
 

--- a/strategies/london_breakout.py
+++ b/strategies/london_breakout.py
@@ -1,3 +1,4 @@
+# ⛔ No indicators required – this strategy uses raw price-action triggers only.
 import pandas as pd
 from .base import BaseStrategy
 

--- a/strategies/macd_divergence.py
+++ b/strategies/macd_divergence.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import pandas_ta as ta
+from utils.indicators import calculate_macd
 from .base import BaseStrategy
 
 class MACDDivergenceStrategy(BaseStrategy):
@@ -11,9 +11,9 @@ class MACDDivergenceStrategy(BaseStrategy):
         if len(data) < 35:
             return
 
-        macd = ta.macd(data['close'])
-        data.loc[:, 'macd'] = macd['MACD_12_26_9']
-        data.loc[:, 'macd_signal'] = macd['MACDs_12_26_9']
+        macd_line, signal_line, _ = calculate_macd(data['close'])
+        data.loc[:, 'macd'] = macd_line
+        data.loc[:, 'macd_signal'] = signal_line
 
         if data['macd'].iloc[-2] < data['macd_signal'].iloc[-2] and data['macd'].iloc[-1] > data['macd_signal'].iloc[-1]:
             self.signal = 'buy'

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from utils.indicators import calculate_ema, calculate_rsi
 from .base import BaseStrategy
 
 class MeanReversionStrategy(BaseStrategy):
@@ -12,9 +13,10 @@ class MeanReversionStrategy(BaseStrategy):
         if len(df) < 30:
             return
 
-        required = {"ema_50", "rsi_14"}
-        if not required.issubset(df.columns):
-            return
+        if "ema_50" not in df.columns:
+            df["ema_50"] = calculate_ema(df["close"], 50)
+        if "rsi_14" not in df.columns:
+            df["rsi_14"] = calculate_rsi(df["close"], 14)
 
         close = df["close"].iloc[-1]
         ema = df["ema_50"].iloc[-1]

--- a/strategies/micro_breakout_scalping.py
+++ b/strategies/micro_breakout_scalping.py
@@ -1,5 +1,5 @@
+# ⛔ No indicators required – this strategy uses raw price-action triggers only.
 import pandas as pd
-import pandas_ta as ta
 from .base import BaseStrategy
 
 class MicroBreakoutScalpingStrategy(BaseStrategy):

--- a/strategies/trend_breakout.py
+++ b/strategies/trend_breakout.py
@@ -2,7 +2,7 @@ import pandas as pd
 from utils.stop_level import enforce_min_sl_tp
 import MetaTrader5 as mt5
 from ai_engine.regime_classifier import detect_market_regime
-from utils.indicators import calculate_atr
+from utils.indicators import calculate_atr, calculate_bollinger_bands
 from .base import BaseStrategy
 
 
@@ -22,11 +22,11 @@ def is_trend_continuation(df: pd.DataFrame, regime: str, lookback: int = 10) -> 
 
 
 def add_bollinger_bands(df: pd.DataFrame, period: int = 20, stddev: float = 2.0) -> pd.DataFrame:
-    """Add basic Bollinger Band columns to ``df`` and return it."""
-    df["bb_mid"] = df["close"].rolling(period).mean()
-    df["bb_std"] = df["close"].rolling(period).std()
-    df["bb_upper"] = df["bb_mid"] + stddev * df["bb_std"]
-    df["bb_lower"] = df["bb_mid"] - stddev * df["bb_std"]
+    """Add Bollinger Band columns using the centralized indicator utils."""
+    upper, mid, lower = calculate_bollinger_bands(df["close"], period, stddev)
+    df["bb_upper"] = upper
+    df["bb_mid"] = mid
+    df["bb_lower"] = lower
     return df
 
 

--- a/strategies/volume_breakout.py
+++ b/strategies/volume_breakout.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from utils.indicators import calculate_ema
 from .base import BaseStrategy
 
 class VolumeBreakoutStrategy(BaseStrategy):
@@ -10,11 +11,14 @@ class VolumeBreakoutStrategy(BaseStrategy):
         if len(data) < 30 or 'volume' not in data.columns:
             return
 
-        avg_volume = data['volume'].rolling(20).mean().iloc[-1]
-        if data['volume'].iloc[-1] > 1.5 * avg_volume:
-            if data['close'].iloc[-1] > data['high'].iloc[-5:-1].max():
+        data = data.copy()
+        data['ema_volume'] = calculate_ema(data['volume'], 20)
+        latest = data.iloc[-1]
+
+        if latest['volume'] > 1.5 * latest['ema_volume']:
+            if latest['close'] > data['high'].rolling(20).max().iloc[-1]:
                 self.signal = 'buy'
-            elif data['close'].iloc[-1] < data['low'].iloc[-5:-1].min():
+            elif latest['close'] < data['low'].rolling(20).min().iloc[-1]:
                 self.signal = 'sell'
 
     def should_buy(self):
@@ -44,8 +48,20 @@ class VolumeBreakoutStrategy(BaseStrategy):
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
         if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):
-            self.signal = None
             return None
-        self.analyze(df)
-        self._log_context(df, pattern_detected="VolumeBreakout")
-        return self.signal
+        df = df.copy()
+        df["ema_volume"] = calculate_ema(df["volume"], 20)
+        latest = df.iloc[-1]
+
+        if latest["volume"] > 1.5 * latest["ema_volume"]:
+            if latest["close"] > df["high"].rolling(20).max().iloc[-1]:
+                signal = "buy"
+            elif latest["close"] < df["low"].rolling(20).min().iloc[-1]:
+                signal = "sell"
+            else:
+                signal = None
+        else:
+            signal = None
+        if signal:
+            self._log_context(df, pattern_detected="VolumeBreakout")
+        return signal

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -1,7 +1,6 @@
 import pandas as pd
-import pandas_ta as ta
+from utils.indicators import calculate_rsi, calculate_vwap
 from .base import BaseStrategy
-from utils.indicators import calculate_rsi
 from core.ict_utils import detect_liquidity_grab
 
 class VWAPReversionStrategy(BaseStrategy):
@@ -20,7 +19,7 @@ class VWAPReversionStrategy(BaseStrategy):
 
         # Calculate VWAP
         data.index = data.index.tz_localize(None)
-        data.loc[:, 'vwap'] = ta.vwap(high=data['high'], low=data['low'], close=data['close'], volume=data['volume'])
+        data.loc[:, 'vwap'] = calculate_vwap(data)
 
         last_price = data['close'].iloc[-1]
         vwap_val = data['vwap'].iloc[-1]

--- a/utils/indicators.py
+++ b/utils/indicators.py
@@ -1,34 +1,64 @@
-# utils/indicators.py
-
 import pandas as pd
 import numpy as np
+import talib
 
 
-def calculate_sma(series: pd.Series, period: int) -> pd.Series:
-    return series.rolling(window=period).mean()
+def calculate_ema(series, period):
+    return talib.EMA(series, timeperiod=period)
 
-def calculate_ema(series: pd.Series, period: int) -> pd.Series:
-    return series.ewm(span=period, adjust=False).mean()
 
-def calculate_vwap(data: pd.DataFrame) -> pd.Series:
-    cumulative_vp = (data['close'] * data['volume']).cumsum()
-    cumulative_volume = data['volume'].cumsum()
-    return cumulative_vp / cumulative_volume
+def calculate_sma(series, period):
+    return talib.SMA(series, timeperiod=period)
 
-def calculate_rsi(series: pd.Series, period: int = 14) -> pd.Series:
-    delta = series.diff()
-    gain = delta.where(delta > 0, 0).rolling(window=period).mean()
-    loss = -delta.where(delta < 0, 0).rolling(window=period).mean()
-    rs = gain / loss
-    return 100 - (100 / (1 + rs))
 
-def calculate_macd(series: pd.Series, fast_period=12, slow_period=26, signal_period=9):
-    ema_fast = calculate_ema(series, fast_period)
-    ema_slow = calculate_ema(series, slow_period)
-    macd_line = ema_fast - ema_slow
-    signal_line = calculate_ema(macd_line, signal_period)
-    histogram = macd_line - signal_line
-    return macd_line, signal_line, histogram
+def calculate_rsi(series, period=14):
+    return talib.RSI(series, timeperiod=period)
+
+
+def calculate_macd(series):
+    macd, signal, hist = talib.MACD(series, fastperiod=12, slowperiod=26, signalperiod=9)
+    return macd, signal, hist
+
+
+def calculate_vwap(df):
+    return ((df['high'] + df['low'] + df['close']) / 3 * df['volume']).cumsum() / df['volume'].cumsum()
+
+
+def calculate_bollinger_bands(series, period=20, dev=2):
+    upper, middle, lower = talib.BBANDS(series, timeperiod=period, nbdevup=dev, nbdevdn=dev, matype=0)
+    return upper, middle, lower
+
+
+def calculate_adx(df, period=14):
+    return talib.ADX(df['high'], df['low'], df['close'], timeperiod=period)
+
+
+def calculate_supertrend(df, period=10, multiplier=3):
+    hl2 = (df['high'] + df['low']) / 2
+    atr = talib.ATR(df['high'], df['low'], df['close'], timeperiod=period)
+
+    upperband = hl2 + multiplier * atr
+    lowerband = hl2 - multiplier * atr
+
+    supertrend = [True] * len(df)
+
+    for i in range(1, len(df)):
+        if df['close'][i] > upperband[i - 1]:
+            supertrend[i] = True
+        elif df['close'][i] < lowerband[i - 1]:
+            supertrend[i] = False
+        else:
+            supertrend[i] = supertrend[i - 1]
+
+            if supertrend[i] and lowerband[i] < lowerband[i - 1]:
+                lowerband[i] = lowerband[i - 1]
+            if not supertrend[i] and upperband[i] > upperband[i - 1]:
+                upperband[i] = upperband[i - 1]
+
+    return pd.Series(supertrend, index=df.index)
+
+
+# Additional helpers retained for compatibility
 
 def calculate_obv(close: pd.Series, volume: pd.Series) -> pd.Series:
     obv = [0]
@@ -41,6 +71,7 @@ def calculate_obv(close: pd.Series, volume: pd.Series) -> pd.Series:
             obv.append(obv[-1])
     return pd.Series(obv, index=close.index)
 
+
 def calculate_fibonacci_levels(high: float, low: float):
     diff = high - low
     return {
@@ -51,61 +82,9 @@ def calculate_fibonacci_levels(high: float, low: float):
         '0.786': high - 0.786 * diff,
     }
 
+
 def calculate_atr(data: pd.DataFrame, period: int = 14) -> pd.Series:
-    high_low = data['high'] - data['low']
-    high_close = abs(data['high'] - data['close'].shift())
-    low_close = abs(data['low'] - data['close'].shift())
-    tr = pd.concat([high_low, high_close, low_close], axis=1).max(axis=1)
-    return tr.rolling(window=period).mean()
-
-def calculate_supertrend(data: pd.DataFrame, period: int = 10, multiplier: float = 3.0) -> pd.Series:
-    hl2 = (data['high'] + data['low']) / 2
-    atr = calculate_atr(data, period)
-    upperband = hl2 + multiplier * atr
-    lowerband = hl2 - multiplier * atr
-
-    direction = []
-    prev_dir = 1
-
-    for i in range(len(data)):
-        if i == 0:
-            direction.append(prev_dir)
-            continue
-
-        close = data['close'].iloc[i]
-        if close > upperband.iloc[i - 1]:
-            curr_dir = 1
-        elif close < lowerband.iloc[i - 1]:
-            curr_dir = -1
-        else:
-            curr_dir = prev_dir
-
-        direction.append(curr_dir)
-        prev_dir = curr_dir
-
-    return pd.Series(direction, index=data.index)
-
-
-def calculate_adx(data: pd.DataFrame, di_length: int = 7, adx_smoothing: int = 7) -> pd.Series:
-    up_move = data['high'].diff()
-    down_move = -data['low'].diff()
-
-    plus_dm = np.where((up_move > down_move) & (up_move > 0), up_move, 0)
-    minus_dm = np.where((down_move > up_move) & (down_move > 0), down_move, 0)
-
-    tr = pd.concat([
-        data['high'] - data['low'],
-        abs(data['high'] - data['close'].shift()),
-        abs(data['low'] - data['close'].shift())
-    ], axis=1).max(axis=1)
-
-    tr_smooth = pd.Series(tr).rolling(di_length).mean()
-    plus_di = 100 * pd.Series(plus_dm).rolling(di_length).mean() / tr_smooth
-    minus_di = 100 * pd.Series(minus_dm).rolling(di_length).mean() / tr_smooth
-
-    dx = 100 * abs(plus_di - minus_di) / (plus_di + minus_di)
-    adx = dx.rolling(adx_smoothing).mean()
-    return adx
+    return talib.ATR(data['high'], data['low'], data['close'], timeperiod=period)
 
 
 def calculate_multi_rsi(data: pd.Series, periods: list) -> dict:


### PR DESCRIPTION
## Summary
- create unified `utils/indicators.py` built on TA‑Lib
- refactor strategies to use indicator helpers
- add dev helper to check indicator usage
- implement volume breakout signal with EMA of volume
- mark price-action-only strategies with notes

## Testing
- `python dev/check_strategy_indicators.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'talib')*

------
https://chatgpt.com/codex/tasks/task_e_686a9550771c832a99ea80f2b940ff03