### PR TITLE
Implement trade metadata enhancements

### DIFF
--- a/core/trade_manager.py
+++ b/core/trade_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import List, Dict
 
 from .risk_evaluator import RiskEvaluator
@@ -10,11 +11,20 @@ from .trade_executor import TradeExecutor
 from .monitor import Monitor
 
 
+# Simple container for currently active trades
+active_trades: List[dict] = []
+
 @dataclass
 class TradeResult:
     ticket: int
     symbol: str
     entry: float
+    entry_time: datetime
+    strategy: str | None = None
+    strategy_type: str = "day"
+    tp_levels: List[float] | None = None
+    tp_hits: int = 0
+    sl_moved: bool = False
 
 
 class TradeManager:
@@ -40,12 +50,61 @@ class TradeManager:
         sl: float,
         tp_list: List[float] | None = None,
         lot: float = 0.01,
+        *,
+        strategy_name: str = "",
+        strategy_type: str = "day",
     ) -> TradeResult:
         ticket = self.executor.execute(symbol, entry_price, lot, sl, tp_list)
         self.monitor.log(
             f"Executed {symbol} at {entry_price} SL={sl} TP={tp_list}"
         )
-        return TradeResult(ticket=ticket, symbol=symbol, entry=entry_price)
+        trade = TradeResult(
+            ticket=ticket,
+            symbol=symbol,
+            entry=entry_price,
+            entry_time=datetime.utcnow(),
+            strategy=strategy_name,
+            strategy_type=strategy_type,
+            tp_levels=tp_list or [],
+        )
+        active_trades.append(trade.__dict__)
+        return trade
 
     def update_after_exit(self, trade_id: int, result: Dict) -> None:
         self.monitor.update(trade_id, result)
+
+    def close_trade(self, trade: Dict) -> None:
+        """Remove trade from active list (placeholder for real close logic)."""
+        if trade in active_trades:
+            active_trades.remove(trade)
+        self.monitor.log(f"Closed trade {trade.get('ticket')}")
+
+    def monitor_active_trades(self) -> None:
+        for trade in list(active_trades):
+            duration = (datetime.utcnow() - trade["entry_time"]).total_seconds() / 60
+            timeout = 240 if trade.get("strategy_type") == "scalp" else 1440
+
+            if duration > timeout:
+                print(f"⏱️ Auto-closing {trade['strategy']} after {duration:.1f} min")
+                trade["exit_reason"] = "timeout_close"
+                self.close_trade(trade)
+
+    def update_stop_loss(self, trade: Dict) -> None:
+        if "tp_hits" not in trade:
+            return
+
+        if trade["tp_hits"] == 1 and not trade.get("sl_moved", False):
+            self.modify_sl(trade, new_sl=trade["entry"])
+            trade["sl_moved"] = True
+            trade["exit_reason"] = "breakeven_locked"
+
+        elif trade["tp_hits"] >= 2:
+            tp2 = trade["tp_levels"][1]
+            new_sl = tp2 - (tp2 - trade["entry"]) * 0.2
+            self.modify_sl(trade, new_sl=round(new_sl, 2))
+            trade["exit_reason"] = "trailing_sl"
+
+    def modify_sl(self, trade: Dict, new_sl: float) -> None:
+        """Placeholder for SL modification call."""
+        trade["sl"] = new_sl
+        self.monitor.log(f"Modify SL for {trade.get('ticket')} -> {new_sl}")

--- a/strategies/base.py
+++ b/strategies/base.py
@@ -13,6 +13,8 @@ class BaseStrategy:
     """Common interface for all strategies."""
 
     strategy_group: str = "day"
+    # Categorize strategies for time-based management
+    strategy_type: str = "day"
     preferred_tf: str = "M15"
     regimes: list[str] | None = None
     # Allowed market regimes for this strategy. Scheduler will block trades if

--- a/strategies/breakout_strategy.py
+++ b/strategies/breakout_strategy.py
@@ -7,6 +7,7 @@ from utils.indicators import (
 
 class BreakoutStrategy(BaseStrategy):
     """Simple breakout strategy using pre-computed indicator columns."""
+    strategy_type = "day"
 
     def __init__(self, lookback: int = 20) -> None:
         self.lookback = lookback

--- a/strategies/delta_scalping.py
+++ b/strategies/delta_scalping.py
@@ -7,6 +7,7 @@ from utils.indicators import (
 )
 
 class DeltaDivergenceScalpingStrategy(BaseStrategy):
+    strategy_type = "scalp"
     def __init__(self):
         self.signal = None
 

--- a/strategies/ema_crossover_scalping.py
+++ b/strategies/ema_crossover_scalping.py
@@ -7,6 +7,7 @@ from utils.indicators import (
 )
 
 class EMACrossoverScalpingStrategy(BaseStrategy):
+    strategy_type = "scalp"
     def __init__(self):
         self.signal = None
 

--- a/strategies/fibonacci_swing.py
+++ b/strategies/fibonacci_swing.py
@@ -7,6 +7,8 @@ from utils.indicators import (
 )
 
 class FibonacciSwingStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/ichimoku_day.py
+++ b/strategies/ichimoku_day.py
@@ -7,6 +7,8 @@ from utils.indicators import (
 )
 
 class IchimokuDayStrategy(BaseStrategy):
+    strategy_type = "day"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/ict_10am_manipulation.py
+++ b/strategies/ict_10am_manipulation.py
@@ -18,6 +18,7 @@ class ICT10AMManipulationStrategy(BaseStrategy):
     """ICT 10AM liquidity manipulation entry."""
 
     strategy_group = "day"
+    strategy_type = "scalp"
 
     def _confirm_ltf_entry(self, ltf_df: pd.DataFrame | None, direction: str) -> bool:
         """Confirm entry on a lower timeframe via engulfing or BOS."""

--- a/strategies/ict_smart_money.py
+++ b/strategies/ict_smart_money.py
@@ -13,6 +13,7 @@ from core.ict_utils import (
 
 class ICTSmartMoneyStrategy(BaseStrategy):
     """Strategy leveraging ICT style concepts."""
+    strategy_type = "day"
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
         if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):

--- a/strategies/london_breakout.py
+++ b/strategies/london_breakout.py
@@ -7,6 +7,8 @@ from utils.indicators import (
 )
 
 class LondonBreakoutStrategy(BaseStrategy):
+    strategy_type = "scalp"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/ma_crossover_swing.py
+++ b/strategies/ma_crossover_swing.py
@@ -7,6 +7,8 @@ from utils.indicators import (
 )
 
 class MACrossoverSwingStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/macd_divergence.py
+++ b/strategies/macd_divergence.py
@@ -3,6 +3,8 @@ from utils.indicators import calculate_macd
 from .base import BaseStrategy
 
 class MACDDivergenceStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/mean_reversion.py
+++ b/strategies/mean_reversion.py
@@ -4,6 +4,7 @@ from .base import BaseStrategy
 
 class MeanReversionStrategy(BaseStrategy):
     """Mean reversion strategy using RSI and EMA indicators."""
+    strategy_type = "day"
 
     def __init__(self) -> None:
         self.signal: str | None = None

--- a/strategies/micro_breakout_scalping.py
+++ b/strategies/micro_breakout_scalping.py
@@ -7,6 +7,7 @@ from utils.indicators import (
 )
 
 class MicroBreakoutScalpingStrategy(BaseStrategy):
+    strategy_type = "scalp"
     def __init__(self):
         self.signal = None
 

--- a/strategies/order_block_scalping.py
+++ b/strategies/order_block_scalping.py
@@ -4,6 +4,7 @@ from utils.indicators import calculate_ema
 from core.price_action import is_bullish_engulfing, is_bearish_engulfing
 
 class OrderBlockScalpingStrategy(BaseStrategy):
+    strategy_type = "scalp"
     def __init__(self):
         self.signal = None
 

--- a/strategies/price_action_strategy.py
+++ b/strategies/price_action_strategy.py
@@ -11,6 +11,7 @@ from core.price_action import (
 
 class PriceActionStrategy(BaseStrategy):
     """Basic strategy using price action utilities."""
+    strategy_type = "day"
 
     def generate_signal(self, df: pd.DataFrame) -> str | None:
         if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):

--- a/strategies/smc_strategy.py
+++ b/strategies/smc_strategy.py
@@ -29,6 +29,7 @@ class SMCStrategy(BaseStrategy):
     """Unifies basic SMC concepts for trade generation."""
 
     strategy_group = "day"
+    strategy_type = "day"
 
     def generate_signal(self, df: pd.DataFrame) -> Dict | None:
         if "atr" in df.columns and not self.is_volatile_enough(df["atr"]):

--- a/strategies/supertrend_adx_rsi_strategy.py
+++ b/strategies/supertrend_adx_rsi_strategy.py
@@ -3,6 +3,8 @@ from utils.indicators import calculate_supertrend, calculate_adx, calculate_mult
 from .base import BaseStrategy
 
 class SupertrendADXRSIStrategy(BaseStrategy):
+    strategy_type = "day"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/supply_demand_swing.py
+++ b/strategies/supply_demand_swing.py
@@ -6,6 +6,8 @@ from utils.indicators import (
 )
 
 class SupplyDemandSwingStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/trend_breakout.py
+++ b/strategies/trend_breakout.py
@@ -58,6 +58,7 @@ def calculate_sl_tp(entry_price: float, regime: str, atr: float, direction: str,
 
 class TrendBreakoutStrategy(BaseStrategy):
     """Breakout strategy that waits for pullbacks within a trend."""
+    strategy_type = "day"
 
     def __init__(self) -> None:
         self.signal: str | None = None

--- a/strategies/trend_following.py
+++ b/strategies/trend_following.py
@@ -5,6 +5,8 @@ from utils.indicators import calculate_sma
 from .base import BaseStrategy
 
 class TrendFollowingStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self, fast_period=10, slow_period=30):
         self.fast_period = fast_period
         self.slow_period = slow_period

--- a/strategies/trend_pullback.py
+++ b/strategies/trend_pullback.py
@@ -7,6 +7,8 @@ from utils.indicators import (
 )
 
 class TrendPullbackStrategy(BaseStrategy):
+    strategy_type = "swing"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/volume_breakout.py
+++ b/strategies/volume_breakout.py
@@ -3,6 +3,8 @@ from utils.indicators import calculate_ema
 from .base import BaseStrategy
 
 class VolumeBreakoutStrategy(BaseStrategy):
+    strategy_type = "day"
+
     def __init__(self):
         self.signal = None
 

--- a/strategies/vwap_reversion.py
+++ b/strategies/vwap_reversion.py
@@ -4,6 +4,8 @@ from .base import BaseStrategy
 from core.ict_utils import detect_liquidity_grab
 
 class VWAPReversionStrategy(BaseStrategy):
+    strategy_type = "scalp"
+
     def __init__(self):
         self.signal = None
 

--- a/utils/trade_journal.py
+++ b/utils/trade_journal.py
@@ -28,6 +28,16 @@ def _save_history(history: List[Dict[str, Any]]) -> None:
         json.dump(history, f, indent=2)
 
 
+def infer_exit_reason(entry: float, exit_price: float | None, sl: float, tps: List[float], result: str | None) -> str:
+    """Best-effort guess of why a trade closed."""
+    if result == "win" and tps:
+        if abs((exit_price or 0) - tps[0]) < 1e-4:
+            return "tp1_hit"
+    if result == "loss" and exit_price is not None and abs(exit_price - sl) < 1e-4:
+        return "sl_hit"
+    return "manual_or_unknown"
+
+
 def record_trade(
     symbol: str,
     timeframe: str,
@@ -107,6 +117,8 @@ def record_trade(
         if volume and commission is not None and swap is not None:
             charges = commission + swap
             calc_net_pct = calc_profit_pct - (charges / (entry * volume * 100000.0) * 100)
+    if exit_reason is None:
+        exit_reason = infer_exit_reason(entry, exit_price, sl, tps, result)
     trade = {
         "symbol": symbol,
         "timeframe": timeframe,


### PR DESCRIPTION
## Summary
- categorize strategies with a strategy_type flag
- track extra metadata when executing trades
- add breakeven & trailing SL management helpers
- auto-close stale trades after timeout
- infer exit reasons when logging trades
- set strategy_type on every strategy

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0ed59f0c832a9dd72bcc0581835d