### PR TITLE
Support strategy-specific timeframes

### DIFF
--- a/agents/strategy_selector_agent.py
+++ b/agents/strategy_selector_agent.py
@@ -43,20 +43,44 @@ class StrategySelectorAgent:
         self.score_path = score_path
         self.asset_score_path = asset_score_path
 
-    def select(self, symbol: str, timeframe: str) -> Tuple[str | None, str | None, str]:
-        df, regime = self.scanner.scan(symbol, timeframe)
-        if df is None:
-            return None, None, regime
+    def select(self, symbol: str, timeframe: str | None = None) -> Tuple[str | None, str | None, str | None, str]:
+        """Evaluate all strategies using their preferred timeframes.
 
+        Returns tuple of (signal, strategy_name, strategy_timeframe, regime).
+        """
         self.memory.run()
 
-        strategies = filter_strategies(self.strategies, regime)
-        if not strategies:
-            return None, None, regime
+        data_cache: dict[str, tuple[pd.DataFrame | None, str]] = {}
+        evaluations = []
 
-        evaluations = self.evaluator.evaluate(
-            strategies, df, regime, symbol=symbol, timeframe=timeframe
-        )
+        for strat in self.strategies:
+            tf = getattr(strat, "preferred_tf", timeframe or "M15")
+            if tf not in data_cache:
+                df, reg = self.scanner.scan(symbol, tf)
+                data_cache[tf] = (df, reg)
+            else:
+                df, reg = data_cache[tf]
+
+            if df is None:
+                continue
+
+            allowed = getattr(strat, "regimes", None)
+            if hasattr(strat, "allowed_regimes"):
+                allowed = strat.allowed_regimes()
+            if allowed and reg not in allowed:
+                continue
+
+            result = self.evaluator.evaluate([strat], df, reg, symbol=symbol, timeframe=tf)
+            if not result:
+                continue
+            ev = result[0]
+            ev["timeframe"] = tf
+            ev["regime"] = reg
+            evaluations.append(ev)
+
+        if not evaluations:
+            return None, None, timeframe, "unknown"
+
         evaluations.sort(key=lambda e: e["score"], reverse=True)
 
         if random.random() < EXPLORATION_PROBABILITY:
@@ -71,19 +95,21 @@ class StrategySelectorAgent:
 
         if evaluation is None:
             debug_log("All strategies blocked by streak guard")
-            return None, None, regime
+            return None, None, evaluations[0].get("timeframe"), evaluations[0].get("regime", "unknown")
 
         strategy = evaluation["strategy"]
-
         score = evaluation["score"]
         signal = evaluation["signal"]
+        tf = evaluation.get("timeframe")
+        reg = evaluation.get("regime", "unknown")
         name = strategy.__class__.__name__
-        logger.info("Evaluated %s: %.2f -> %s", name, score, signal)
+
+        logger.info("Evaluated %s (%s): %.2f -> %s", name, tf, score, signal)
 
         if signal in ("buy", "sell") and score >= MIN_CONFIDENCE:
-            return signal, name, regime
+            return signal, name, tf, reg
 
         debug_log(
-            f"{name} {symbol} {timeframe} signal={signal} score={score:.2f} < {MIN_CONFIDENCE}"
+            f"{name} {symbol} {tf} signal={signal} score={score:.2f} < {MIN_CONFIDENCE}"
         )
-        return None, name, regime
+        return None, name, tf, reg

--- a/live/scheduler_loop.py
+++ b/live/scheduler_loop.py
@@ -138,6 +138,12 @@ daily_guard_trigger_date: date | None = None
 # Track currently open trades per symbol/timeframe
 active_trades: dict[tuple[str, str], bool] = {}
 strategy_selector_agent = StrategySelectorAgent(StrategySelector().strategies)
+
+# Expand TIMEFRAMES to include each strategy's preferred timeframe
+strategy_tfs = {getattr(s, "preferred_tf", "M15") for s in strategy_selector_agent.strategies}
+TIMEFRAMES = sorted(set(TIMEFRAMES) | strategy_tfs)
+ACTIVE_SYMBOLS_TIMEFRAMES = {s: TIMEFRAMES for s in SYMBOLS}
+
 risk_manager_agent = RiskManagerAgent()
 smc_strategy = SMCStrategy()
 
@@ -361,7 +367,7 @@ def process_symbol_timeframe(symbol: str, timeframe: str, *, force_trade: bool =
         active_trades[(symbol, timeframe)] = True
         return
 
-    decision, best_strat, market_regime = strategy_selector_agent.select(symbol, timeframe)
+    decision, best_strat, strat_tf, market_regime = strategy_selector_agent.select(symbol, timeframe)
     if decision not in ("buy", "sell") or not best_strat:
         logger.warning(
             f"[SKIP] Trade skipped: {symbol} {timeframe} - Reason: No valid signal"
@@ -369,7 +375,7 @@ def process_symbol_timeframe(symbol: str, timeframe: str, *, force_trade: bool =
         return
     
     logger.info(
-        f"[SIGNAL GENERATED] {best_strat} | {symbol} {timeframe} → {decision.upper()}"
+        f"[SIGNAL GENERATED] {best_strat} | {symbol} {strat_tf} → {decision.upper()}"
     )
     # Regime enforcement: block trades if strategy not allowed in detected regime
     strat_obj = next(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -64,9 +64,10 @@ def test_strategy_selector_agent(tmp_path, monkeypatch):
         score_path=str(score_path),
         asset_score_path=str(score_path),
     )
-    decision, strat_name, regime = agent.select("XAUUSD", "M1")
+    decision, strat_name, tf, regime = agent.select("XAUUSD", "M1")
     assert decision == "buy"
     assert strat_name == "GoodStrategy"
+    assert tf == "M15"
     assert regime == "trending"
 
 


### PR DESCRIPTION
## Summary
- evaluate strategies using their `preferred_tf` timeframe
- expand bot timeframes based on strategy definitions
- adjust logging for selected timeframe
- update unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b12b8afdc832a8d23f9d91fa142b6