### PR TITLE
Add multi-position break logic and improve SL checks

### DIFF
--- a/execution/multi_tp_manager.py
+++ b/execution/multi_tp_manager.py
@@ -71,14 +71,18 @@ def handle_order_close(ticket: int, price: float) -> None:
     remaining = [t for t in data["tickets"] if t != ticket and t in _ticket_map]
     entry = data["entry"]
     tp_levels = data["tp_levels"]
-    sl_buffer = data.get("sl_buffer", 0.0)
+    symbol = data.get("symbol", "")
+    info = mt5.symbol_info(symbol)
+    point = getattr(info, "point", 0.0) if info else 0.0
     if idx == 0 and remaining:
+        # Position A hit TP1 -> move B & C SL to entry + 20 pips
+        offset = 20 * point * 10
+        new_sl = entry + offset if data["direction"] == "buy" else entry - offset
         for t in remaining:
-            _modify_sl(t, entry, [0])
+            _modify_sl(t, new_sl, [0])
     elif idx == 1 and remaining:
-        # Only one ticket should remain
-        buffer_adj = sl_buffer if data["direction"] == "buy" else -sl_buffer
-        new_sl = tp_levels[1] - buffer_adj
+        # Position B hit TP2 -> set C SL to TP1 level
+        new_sl = tp_levels[0]
         _modify_sl(remaining[0], new_sl, [0, 1])
 
     if not remaining:

--- a/live/scheduler_loop.py
+++ b/live/scheduler_loop.py
@@ -88,7 +88,7 @@ def is_valid_sl_tp(symbol: str, order_type: str, price: float, sl: float, tp: fl
     info = mt5.symbol_info(symbol)
     if not info:
         return False
-    stop_level = info.trade_stops_level * info.point
+    stop_level = getattr(info, "trade_stops_level", getattr(info, "stops_level", 0)) * info.point
 
     if order_type == "buy":
         if sl >= price or tp <= price:
@@ -108,7 +108,7 @@ def auto_adjust_sl_tp(symbol: str, order_type: str, price: float, sl: float, tp:
     info = mt5.symbol_info(symbol)
     if not info:
         return sl, tp
-    min_dist = info.trade_stops_level * info.point
+    min_dist = getattr(info, "trade_stops_level", getattr(info, "stops_level", 0)) * info.point
     if order_type == "buy":
         sl = min(sl, price - min_dist)
         tp = max(tp, price + min_dist)
@@ -743,11 +743,18 @@ def run_live_trade_manager() -> None:
                     reached_tps=list(bem.reached_tps),
                 )
                 alert_sl_moved(pos.symbol, rec["timeframe"], new_sl)
-        # simple reversal check
-        if direction == "buy" and price < rec["entry"] - (rec["entry"] - rec["sl"]):
-            close_type = mt5.ORDER_TYPE_SELL
-        elif direction == "sell" and price > rec["entry"] + (rec["sl"] - rec["entry"]):
-            close_type = mt5.ORDER_TYPE_BUY
+        # simple reversal check only after any TP hit
+        tp_hit_flag = any(
+            rec.get(k)
+            for k in ("tp1_hit", "tp2_hit", "tp3_hit")
+        )
+        if tp_hit_flag:
+            if direction == "buy" and price < rec["entry"] - (rec["entry"] - rec["sl"]):
+                close_type = mt5.ORDER_TYPE_SELL
+            elif direction == "sell" and price > rec["entry"] + (rec["sl"] - rec["entry"]):
+                close_type = mt5.ORDER_TYPE_BUY
+            else:
+                close_type = None
         else:
             close_type = None
         if close_type is not None:


### PR DESCRIPTION
## Summary
- ensure stop level validation uses available MT5 fields
- trigger reversal closes only after a TP is reached
- update multi_tp_manager to adjust stops across positions when TP1/TP2 hit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c594d8cc4832ab808e8cdeafa3c5b