### PR TITLE
Enforce MT5 trades & new strategy score handler

### DIFF
--- a/agents/trade_monitor_agent.py
+++ b/agents/trade_monitor_agent.py
@@ -6,7 +6,7 @@ import logging
 
 import MetaTrader5 as mt5
 
-from ai_engine.score_updater import update_strategy_score
+from core.strategy_score_handler import update_strategy_score
 from utils.trade_journal import update_trade, load_history
 from utils.cooldown_tracker import set_strategy_cooldown
 from execution.multi_tp_manager import handle_order_close

--- a/ai_engine/learning_mode.py
+++ b/ai_engine/learning_mode.py
@@ -2,7 +2,7 @@ import json
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 # Reuse the existing score management utilities
-from ai_engine.strategy_score_manager import update_strategy_score
+from core.strategy_score_handler import update_strategy_score
 
 
 def run_learning_mode_ml(trade_file="logs/trade_history.json"):

--- a/ai_engine/trade_replayer.py
+++ b/ai_engine/trade_replayer.py
@@ -8,7 +8,7 @@ import os
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 
-from ai_engine.score_updater import load_scores, update_strategy_score
+from core.strategy_score_handler import load_scores, update_strategy_score
 
 HISTORY_PATH = "logs/trade_history.json"
 SCORE_PATH = "ai_engine/strategy_scores.json"

--- a/backtesting/live_simulator.py
+++ b/backtesting/live_simulator.py
@@ -9,7 +9,7 @@ from strategies.strategy_selector import StrategySelector
 from execution.order_manager import execute_fake_order
 from risk_management.position_sizer import calculate_position_size_and_targets
 from utils.trade_logger import log_trade
-from ai_engine.score_updater import update_strategy_score
+from core.strategy_score_handler import update_strategy_score
 from datetime import datetime
 from utils.summary_reporter import generate_daily_summary
 

--- a/core/strategy_score_handler.py
+++ b/core/strategy_score_handler.py
@@ -1,0 +1,59 @@
+import json
+import os
+from typing import Dict
+
+USED_SCORE_FILE = "Used_strategy_score.json"
+BASE_SCORE_FILE = "Base_strategy_score.json"
+
+
+def _load_json(path: str) -> Dict:
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def load_scores(
+    base_path: str = BASE_SCORE_FILE, used_path: str | None = None
+) -> Dict:
+    if used_path is None:
+        used_path = USED_SCORE_FILE
+    base_scores = _load_json(base_path)
+    used_scores = _load_json(used_path)
+    merged = base_scores.copy()
+    for name, score in used_scores.items():
+        merged[name] = score
+    return merged
+
+
+def get_strategy_score(name: str, *, base_path: str = BASE_SCORE_FILE, used_path: str | None = None) -> float:
+    scores = load_scores(base_path=base_path, used_path=used_path)
+    return float(scores.get(name, 0.0))
+
+
+def update_strategy_score(name: str, *args, **kwargs) -> None:
+    """Record ``name`` score in ``USED_SCORE_FILE``.
+
+    This accepts arbitrary arguments for compatibility with older call
+    signatures. ``score`` can be provided directly via keyword or the
+    second positional argument.
+    """
+
+    score = kwargs.get("score")
+    result = kwargs.get("result")
+    if score is None and args:
+        if isinstance(args[0], (int, float)):
+            score = args[0]
+        else:
+            result = args[0]
+    if score is None:
+        score = 1.0 if str(result).startswith("win") or str(result).startswith("tp") else 0.0
+
+    used_path = kwargs.get("score_path", USED_SCORE_FILE)
+    used = _load_json(used_path)
+    used[name] = float(score)
+    with open(used_path, "w", encoding="utf-8") as f:
+        json.dump(used, f, indent=2)

--- a/core/trade_engine.py
+++ b/core/trade_engine.py
@@ -1,0 +1,139 @@
+import time
+import logging
+import MetaTrader5 as mt5
+
+from config.manager import get_config
+from execution.order_manager import execute_fake_order
+from monitoring.alert_manager import alert_trade_opened
+from utils.market_status import is_market_open
+from utils.stop_level import enforce_min_stop_distance
+
+MAGIC_NUMBER = int(get_config("MAGIC_NUMBER", 123456))
+
+logger = logging.getLogger(__name__)
+
+
+def is_valid_sl_tp(symbol: str, order_type: str, price: float, sl: float, tp: float) -> bool:
+    """Validate SL/TP against broker stop levels."""
+    info = mt5.symbol_info(symbol)
+    if not info:
+        return False
+    stop_level = getattr(info, "trade_stops_level", getattr(info, "stops_level", 0)) * info.point
+
+    if order_type == "buy":
+        if sl >= price or tp <= price:
+            return False
+        if (price - sl) < stop_level or (tp - price) < stop_level:
+            return False
+    else:
+        if sl <= price or tp >= price:
+            return False
+        if (sl - price) < stop_level or (price - tp) < stop_level:
+            return False
+    return True
+
+
+def execute_trade(
+    direction: str, symbol: str, lot: float, sl: float, tp: float, magic_offset: int = 0
+) -> int | None:
+    if not is_market_open(symbol):
+        logger.warning(f"[SKIP] Market is closed for {symbol}, skipping trade.")
+        return None
+    info = mt5.symbol_info(symbol)
+    if not info:
+        logger.error(f"\u26a0\ufe0f Failed to fetch SymbolInfo for {symbol}")
+        return None
+    trade_mode = getattr(info, "trade_mode", None)
+    if trade_mode in (0, 3):
+        logger.warning(f"{symbol} not tradeable now (market closed or disabled)")
+        return None
+
+    price_tick = mt5.symbol_info_tick(symbol)
+    if price_tick is None:
+        logging.warning(f"No price data for {symbol}")
+        return None
+
+    entry_price = price_tick.ask if direction == "buy" else price_tick.bid
+
+    if not is_valid_sl_tp(symbol, direction, entry_price, sl, tp):
+        info = mt5.symbol_info(symbol)
+        stop_level = info.trade_stops_level * info.point if info else 0
+        print(f"[VALIDATION FAILED] {symbol} ({direction})")
+        print(
+            f"Entry={entry_price:.2f}, SL={sl:.2f}, TP={tp:.2f}, MinStop={stop_level:.2f}"
+        )
+        print(
+            f"\u274c Invalid SL/TP for {symbol} - Order rejected due to broker stop limits."
+        )
+        return None
+
+    sl, _, valid = enforce_min_stop_distance(symbol, entry_price, sl, tp, direction)
+    if not valid:
+        return None
+
+    print(f"\U0001F4E4 Executing {direction.upper()} on {symbol} @ {entry_price:.2f}")
+    print(f"    SL: {sl:.2f} | TP: {tp:.2f}")
+    if get_config("LIVE_MODE", "false").lower() != "true":
+        logger.debug(
+            "[SIM MODE] %s %s lot=%.2f price=%.5f sl=%s tp=%s",
+            direction,
+            symbol,
+            lot,
+            entry_price,
+            sl,
+            tp,
+        )
+        execute_fake_order(direction, symbol, lot, entry_price, sl=sl, tp=tp)
+        alert_trade_opened(symbol, "sim", direction, entry_price, sl, tp)
+        return int(time.time())
+
+    deal_type = mt5.ORDER_TYPE_BUY if direction == "buy" else mt5.ORDER_TYPE_SELL
+    symbol_info = mt5.symbol_info(symbol)
+    type_filling = mt5.ORDER_FILLING_IOC  # default fallback
+    override = get_config("FILLING_MODE_OVERRIDES", {})
+    if symbol in override:
+        type_filling = int(override[symbol])
+    elif symbol_info and hasattr(symbol_info, "filling_mode"):
+        if symbol_info.filling_mode in (
+            mt5.ORDER_FILLING_IOC,
+            mt5.ORDER_FILLING_FOK,
+            mt5.ORDER_FILLING_RETURN,
+        ):
+            type_filling = symbol_info.filling_mode
+    request = {
+        "action": mt5.TRADE_ACTION_DEAL,
+        "symbol": symbol,
+        "volume": lot,
+        "type": deal_type,
+        "price": entry_price,
+        "sl": sl,
+        "tp": tp,
+        "deviation": 20,
+        "magic": MAGIC_NUMBER + magic_offset,
+        "comment": "AI Trade",
+        "type_time": mt5.ORDER_TIME_GTC,
+        "type_filling": type_filling,
+    }
+    if tp and tp > 0:
+        request["tp"] = tp
+    info = mt5.symbol_info(symbol)
+    if not info or info.trade_mode != mt5.SYMBOL_TRADE_MODE_FULL:
+        logger.warning(f"{symbol} is not tradeable now (market closed or disabled)")
+        return None
+    logger.info(f"Sending order for {symbol}...")
+    logger.debug("Order details: %s", request)
+    result = mt5.order_send(request)
+    logger.debug(
+        "MT5 retcode=%s comment=%s", getattr(result, "retcode", None), getattr(result, "comment", "")
+    )
+    if result and result.retcode == mt5.TRADE_RETCODE_DONE:
+        logger.info("Trade executed: ticket %s", result.order)
+        alert_trade_opened(symbol, "live", direction, entry_price, sl, tp)
+        return result.order
+    logger.error(
+        "Trade failed: retcode=%s reason=%s response=%s",
+        getattr(result, "retcode", None),
+        getattr(result, "comment", ""),
+        result,
+    )
+    return result

--- a/live/scheduler_loop.py
+++ b/live/scheduler_loop.py
@@ -54,10 +54,9 @@ from connectors.mt5_connector import get_account_info
 from utils.trade_journal import record_trade, update_trade, load_history
 from utils.logger import log_trade_action
 from risk_management.breakeven_manager import BreakEvenManager
-from execution.order_manager import execute_fake_order
 from ai_engine.strategy_score_manager import recover_old_scores
+from core.trade_engine import execute_trade
 from monitoring.alert_manager import (
-    alert_trade_opened,
     alert_sl_moved,
     alert_trade_closed,
     alert_daily_guard,
@@ -83,39 +82,6 @@ from strategy_components.session_filter import (
 logger = logging.getLogger("scheduler")
 
 
-def is_valid_sl_tp(symbol: str, order_type: str, price: float, sl: float, tp: float) -> bool:
-    """Validate SL/TP against broker stop levels."""
-    info = mt5.symbol_info(symbol)
-    if not info:
-        return False
-    stop_level = getattr(info, "trade_stops_level", getattr(info, "stops_level", 0)) * info.point
-
-    if order_type == "buy":
-        if sl >= price or tp <= price:
-            return False
-        if (price - sl) < stop_level or (tp - price) < stop_level:
-            return False
-    else:
-        if sl <= price or tp >= price:
-            return False
-        if (sl - price) < stop_level or (price - tp) < stop_level:
-            return False
-    return True
-
-
-def auto_adjust_sl_tp(symbol: str, order_type: str, price: float, sl: float, tp: float) -> tuple[float, float]:
-    """Adjust SL/TP to satisfy minimum stop level requirements."""
-    info = mt5.symbol_info(symbol)
-    if not info:
-        return sl, tp
-    min_dist = getattr(info, "trade_stops_level", getattr(info, "stops_level", 0)) * info.point
-    if order_type == "buy":
-        sl = min(sl, price - min_dist)
-        tp = max(tp, price + min_dist)
-    else:
-        sl = max(sl, price + min_dist)
-        tp = min(tp, price - min_dist)
-    return sl, tp
 
 def get_confidence_threshold(symbol: str, timeframe: str, regime: str, strategy_name: str) -> float:
     """Return confidence threshold for a trade context."""
@@ -209,111 +175,6 @@ def refresh_data(symbol: str, timeframe: str, limit: int = 300) -> None:
     enriched = add_indicators(clean)
     indicator_cache[(symbol, timeframe)] = enriched[symbol][timeframe]
 
-def execute_trade(
-    direction: str, symbol: str, lot: float, sl: float, tp: float, magic_offset: int = 0
-) -> int | None:
-    if not is_market_open(symbol):
-        logger.warning(f"[SKIP] Market is closed for {symbol}, skipping trade.")
-        return None
-    info = mt5.symbol_info(symbol)
-    if not info:
-        logger.error(f"\u26a0\ufe0f Failed to fetch SymbolInfo for {symbol}")
-        return None
-    trade_mode = getattr(info, "trade_mode", None)
-    if trade_mode in (0, 3):
-        logger.warning(f"{symbol} not tradeable now (market closed or disabled)")
-        return None
-
-    price_tick = mt5.symbol_info_tick(symbol)
-    if price_tick is None:
-        logging.warning(f"No price data for {symbol}")
-        return None
-
-    entry_price = price_tick.ask if direction == "buy" else price_tick.bid
-
-    if not is_valid_sl_tp(symbol, direction, entry_price, sl, tp):
-        info = mt5.symbol_info(symbol)
-        stop_level = info.trade_stops_level * info.point if info else 0
-        print(f"[VALIDATION FAILED] {symbol} ({direction})")
-        print(
-            f"Entry={entry_price:.2f}, SL={sl:.2f}, TP={tp:.2f}, MinStop={stop_level:.2f}"
-        )
-        print(
-            f"\u274c Invalid SL/TP for {symbol} - Order rejected due to broker stop limits."
-        )
-        return None
-
-    sl, _, valid = enforce_min_stop_distance(symbol, entry_price, sl, tp, direction)
-    if not valid:
-        return None
-
-    print(f"\U0001F4E4 Executing {direction.upper()} on {symbol} @ {entry_price:.2f}")
-    print(f"    SL: {sl:.2f} | TP: {tp:.2f}")
-    if get_config("LIVE_MODE", "false").lower() != "true":
-        logger.debug(
-            "[SIM MODE] %s %s lot=%.2f price=%.5f sl=%s tp=%s",
-            direction,
-            symbol,
-            lot,
-            entry_price,
-            sl,
-            tp,
-        )
-        execute_fake_order(direction, symbol, lot, entry_price, sl=sl, tp=tp)
-        alert_trade_opened(symbol, "sim", direction, entry_price, sl, tp)
-        return int(time.time())
-
-    deal_type = mt5.ORDER_TYPE_BUY if direction == "buy" else mt5.ORDER_TYPE_SELL
-    symbol_info = mt5.symbol_info(symbol)
-    type_filling = mt5.ORDER_FILLING_IOC  # default fallback
-    # Optional: make it dynamic per-symbol from config
-    override = get_config("FILLING_MODE_OVERRIDES", {})
-    if symbol in override:
-        type_filling = int(override[symbol])
-    elif symbol_info and hasattr(symbol_info, "filling_mode"):
-        if symbol_info.filling_mode in (
-            mt5.ORDER_FILLING_IOC,
-            mt5.ORDER_FILLING_FOK,
-            mt5.ORDER_FILLING_RETURN,
-        ):
-            type_filling = symbol_info.filling_mode
-    request = {
-        "action": mt5.TRADE_ACTION_DEAL,
-        "symbol": symbol,
-        "volume": lot,
-        "type": deal_type,
-        "price": entry_price,
-        "sl": sl,
-        "tp": tp,
-        "deviation": 20,
-        "magic": MAGIC_NUMBER + magic_offset,
-        "comment": "AI Trade",
-        "type_time": mt5.ORDER_TIME_GTC,
-        "type_filling": type_filling,
-    }
-    if tp and tp > 0:
-        request["tp"] = tp
-    info = mt5.symbol_info(symbol)
-    if not info or info.trade_mode != mt5.SYMBOL_TRADE_MODE_FULL:
-        logger.warning(f"{symbol} is not tradeable now (market closed or disabled)")
-        return None
-    logger.info(f"Sending order for {symbol}...")
-    logger.debug("Order details: %s", request)
-    result = mt5.order_send(request)
-    logger.debug(
-        "MT5 retcode=%s comment=%s", getattr(result, "retcode", None), getattr(result, "comment", "")
-    )
-    if result and result.retcode == mt5.TRADE_RETCODE_DONE:
-        logger.info("Trade executed: ticket %s", result.order)
-        alert_trade_opened(symbol, "live", direction, entry_price, sl, tp)
-        return result.order
-    logger.error(
-        "Trade failed: retcode=%s reason=%s response=%s",
-        getattr(result, "retcode", None),
-        getattr(result, "comment", ""),
-        result,
-    )
-    return None
 
 
 def process_symbol_timeframe(symbol: str, timeframe: str, *, force_trade: bool = False) -> None:

--- a/strategies/ema_crossover_scalping.py
+++ b/strategies/ema_crossover_scalping.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas_ta as ta
 from .base import BaseStrategy
 from utils.indicators import (
     calculate_ema, calculate_sma, calculate_rsi, calculate_macd,

--- a/strategies/ichimoku_day.py
+++ b/strategies/ichimoku_day.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas_ta as ta
 from .base import BaseStrategy
 from utils.indicators import (
     calculate_ema, calculate_sma, calculate_rsi, calculate_macd,

--- a/strategies/ma_crossover_swing.py
+++ b/strategies/ma_crossover_swing.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas_ta as ta
 from .base import BaseStrategy
 from utils.indicators import (
     calculate_ema, calculate_sma, calculate_rsi, calculate_macd,

--- a/strategies/trend_pullback.py
+++ b/strategies/trend_pullback.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pandas_ta as ta
 from .base import BaseStrategy
 from utils.indicators import (
     calculate_ema, calculate_sma, calculate_rsi, calculate_macd,

--- a/tests/test_live_mode.py
+++ b/tests/test_live_mode.py
@@ -1,7 +1,8 @@
 import types
 
 import MetaTrader5 as mt5
-from live import scheduler_loop
+from core import trade_engine
+from execution import order_manager
 
 
 def test_execute_trade_uses_mock(monkeypatch):
@@ -25,9 +26,9 @@ def test_execute_trade_uses_mock(monkeypatch):
     )
     monkeypatch.setattr(mt5, "symbol_info", lambda symbol: info)
     
-    monkeypatch.setattr(scheduler_loop, "execute_fake_order", lambda *a, **k: calls.append((a, k)) or 123)
+    monkeypatch.setattr(trade_engine, "execute_fake_order", lambda *a, **k: calls.append((a, k)) or 123)
 
-    ticket = scheduler_loop.execute_trade("buy", "XAUUSD.", 0.1, 1.0, 2.0)
+    ticket = trade_engine.execute_trade("buy", "XAUUSD.", 0.1, 1.0, 2.0)
 
     assert isinstance(ticket, int)
     assert calls and calls[0][0][0] == "buy"

--- a/utils/trade_journal.py
+++ b/utils/trade_journal.py
@@ -7,7 +7,7 @@ import os
 from datetime import datetime
 from typing import Any, Dict, List
 
-from ai_engine.score_updater import update_strategy_score
+from core.strategy_score_handler import update_strategy_score
 
 HISTORY_PATH = "logs/trade_history.json"
 


### PR DESCRIPTION
## Summary
- centralize trade execution in `core/trade_engine` and remove old logic
- import `execute_trade` in scheduler loop
- add simple strategy score handler with base/used files
- update agents and utilities to use new score handler
- drop unused pandas_ta imports
- adjust tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741c2038ac832a891b7e1462727132